### PR TITLE
Fixed opperator spelling error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@ lint 0.2
 --------
 
 * Added support for generic function styles.
-* Added styles for assignment opperators, based on functional styles.
+* Added styles for assignment operators, based on functional styles.
 * Added performance improvement style for squaring numbers.
 
 

--- a/R/styles.assignment.R
+++ b/R/styles.assignment.R
@@ -28,7 +28,7 @@
 #' @title Assignemnt Style
 #' @name assignment-styles
 #' @docType data 
-#' @format style tests for assignment opperators.
+#' @format style tests for assignment operators.
 #'  
 #' @include finders.R
 #' @exportPattern styles\\.assignment\\..*

--- a/R/styles.spacing.R
+++ b/R/styles.spacing.R
@@ -120,7 +120,7 @@ spacing.spacearoundinfix <- {list(
                       , '(', infix.noeq, ')')
               , paste0( '(', infix.noeq, ')'
                       , no.trailing.percent, no.trailing.space.rx))
-  , message = "needs space around infix opperators"
+  , message = "needs space around infix operators"
   , exclude.region = c("find_comment", "find_string", "find_symbol", "find_number")
 )}
 .testinfo.spacing.spacearoundinfix <- {list(


### PR DESCRIPTION
Hi, you asked for this to be done via github, so here is the first correction. 

The tests have not yet been corrected.
